### PR TITLE
allow all fighters to pick quarterstaff

### DIFF
--- a/crawl-ref/source/ng-restr.cc
+++ b/crawl-ref/source/ng-restr.cc
@@ -101,12 +101,6 @@ char_choice_restriction weapon_restriction(weapon_type wpn,
         return CC_RESTRICTED;
     }
 
-    if (wpn == WPN_QUARTERSTAFF && ng.job != JOB_GLADIATOR
-        && !(ng.job == JOB_FIGHTER && ng.species == SP_FORMICID))
-    {
-        return CC_BANNED;
-    }
-
     // Javelins are always good, tomahawks not so much.
     if (wpn == WPN_THROWN)
     {


### PR DESCRIPTION
If a player wants to start with a quarterstaff and a shield, let them. They may be planning to transition into an enhancer staff later in their career, or perhaps they just want to lean on the awesome early game power of a quarterstaff while they train up shields and other skills. It's generally seen as a bad idea to leave your shield equipped without further training anyways.
