### PR TITLE
Update book-data.h

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -300,10 +300,10 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Debilitation
     SPELL_CORONA,
     SPELL_SLOW,
-    SPELL_GRAVITAS,
+    SPELL_TUKIMAS_DANCE,
     SPELL_INNER_FLAME,
     SPELL_CAUSE_FEAR,
-    SPELL_LEDAS_LIQUEFACTION,
+    SPELL_SUMMON_MANA_VIPER,
 },
 
 {   // Book of the Dragon

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -202,6 +202,7 @@ static const vector<spell_type> spellbook_templates[] =
 
 {   // Book of the Warp
     SPELL_RECALL,
+    SPELL_PORTAL_PROJECTILE,
     SPELL_GRAVITAS,
     SPELL_FORCE_LANCE,
     SPELL_WARP_BRAND,


### PR DESCRIPTION
Step 1 of minor Arcane Marksman revamp: replace general-purpose shitty-spells with spells that make you great at hunting specific enemies. Also, Tukima's Dance is FUN and people play things that are FUN.

This is the least popular role in the game right now by a huge margin. It is slightly over HALF as popular as the second-most-unpopular role, Warper.
