### PR TITLE
Update player.cc

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2011,17 +2011,17 @@ int player_movement_speed()
     if (you.run())
         mv -= 200;
 
-//	if (you.species == SP_LAVA_ORC) {
-//		if (you.temperature < TEMP_COOL) {
-//			mv += 100;
+	if (you.species == SP_LAVA_ORC) {
+		if (you.temperature < TEMP_COOL) {
+			mv += 100;
 //		}
 //		if (you.temperature >= TEMP_ROOM) {
 //			mv -= 100;
 //		}
 //		if (you.temperature >= TEMP_HOT) {
 //			mv -= 100;
-//		}
-//	}
+		}
+	}
 
     mv += you.wearing_ego(EQ_ALL_ARMOUR, SPARM_PONDEROUSNESS) * 100;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1793,7 +1793,7 @@ int player_spec_fire()
     // rings of fire:
     sf += you.wearing(EQ_RINGS, RING_FIRE);
 
-    if (you.species == SP_LAVA_ORC && temperature_effect(LORC_FIRE_BOOST))
+    if (you.species == SP_LAVA_ORC && temperature_effect(LORC_LAVA_BOOST)) 
         sf++;
 
     if (you.duration[DUR_FIRE_SHIELD])
@@ -1828,6 +1828,9 @@ int player_spec_earth()
 
     // Staves
     se += you.wearing(EQ_STAFF, STAFF_EARTH);
+    
+    if (you.species == SP_LAVA_ORC && temperature_effect(LORC_LAVA_BOOST)) 
+        se++;
 
     return se;
 }
@@ -2008,17 +2011,17 @@ int player_movement_speed()
     if (you.run())
         mv -= 200;
 
-	if (you.species == SP_LAVA_ORC) {
-		if (you.temperature < TEMP_COOL) {
-			mv += 100;
-		}
-		if (you.temperature >= TEMP_ROOM) {
-			mv -= 100;
-		}
-		if (you.temperature >= TEMP_HOT) {
-			mv -= 100;
-		}
-	}
+//	if (you.species == SP_LAVA_ORC) {
+//		if (you.temperature < TEMP_COOL) {
+//			mv += 100;
+//		}
+//		if (you.temperature >= TEMP_ROOM) {
+//			mv -= 100;
+//		}
+//		if (you.temperature >= TEMP_HOT) {
+//			mv -= 100;
+//		}
+//	}
 
     mv += you.wearing_ego(EQ_ALL_ARMOUR, SPARM_PONDEROUSNESS) * 100;
 
@@ -6458,14 +6461,17 @@ int player::racial_ac(bool temp) const
     if (!(player_is_shapechanged() && temp))
     {
         if (species == SP_NAGA)
-            return 100 * experience_level / 3;              // max 9
+            return 100 * experience_level / 3;  		// max 9
+        if (species == SP_LAVA_ORC)
+            && temperature() < TEMP_WARM; 			// 1-8
+            return 300 + 100 * experience_level / 9;		// max 6 or so
         else if (species == SP_GARGOYLE)
         {
-            return 200 + 100 * experience_level * 2 / 5     // max 20
+            return 200 + 100 * experience_level * 2 / 5     	// max 20
                        + 100 * (max(0, experience_level - 7) * 2 / 5);
         }
     }
-
+    
     return 0;
 }
 
@@ -7820,7 +7826,7 @@ bool player::cannot_act() const
 
 bool player::can_throw_large_rocks() const
 {
-    return species_can_throw_large_rocks(species) || you.strength(true) > 30;
+    return species_can_throw_large_rocks(species);
 }
 
 bool player::can_smell() const
@@ -8517,11 +8523,12 @@ bool temperature_effect(int which)
 //      case nothing, right now:
 //            return (you.temperature >= TEMP_COOL && you.temperature < TEMP_WARM); // 5-8
         case LORC_LAVA_BOOST:
-            return temperature() >= TEMP_WARM && temperature() < TEMP_HOT; // 9-10
+            return temperature() >= TEMP_WARM // 9-10
+        			  // && temperature() < TEMP_HOT;
         case LORC_FIRE_RES_II:
             return temperature() >= TEMP_WARM; // 9-15
+//        case LORC_FIRE_BOOST:
         case LORC_FIRE_RES_III:
-        case LORC_FIRE_BOOST:
         case LORC_COLD_VULN:
             return temperature() >= TEMP_HOT; // 11-15
         case LORC_PASSIVE_HEAT:
@@ -8569,11 +8576,11 @@ string temperature_text(int temp)
         case TEMP_WARM:
             return "rF++; lava magic boost; Stoneskin melts";
         case TEMP_HOT:
-            return "rF+++; rC-; fire magic boost";
+            return "rF+++; rC-";
         case TEMP_FIRE:
             return "Burn attackers";
         case TEMP_MAX:
-            return "Burn surroundings; cannot read scrolls";
+            return "All above effects, fire aura; can't read.";
         default:
             return "";
     }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6463,7 +6463,7 @@ int player::racial_ac(bool temp) const
         if (species == SP_NAGA)
             return 100 * experience_level / 3;  		// max 9
         if (species == SP_LAVA_ORC)
-            && temperature() < TEMP_WARM; 			// 1-8
+            && (you.temperature >= TEMP_WARM); 			// 1-8
             return 300 + 100 * experience_level / 9;		// max 6 or so
         else if (species == SP_GARGOYLE)
         {


### PR DESCRIPTION
I am 90% certain these changes will work. By simplifying the lava / fire boost into just "lava boost", there's no longer a case where at high temp you get some of the benefits of lower temperature tiers, but not all.

If max temp orcs can't read books, also, that saves us some length in the text string. :D ("can't read")
