### PR TITLE
Update melee_attack.cc

### DIFF
--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -3272,7 +3272,7 @@ void melee_attack::do_spines()
 
         if (mut && attacker->alive() && coinflip())
         {
-            int dmg = roll_dice(1 + mut, 5);
+ +          int dmg = random_range(mut, 3 + ceil(mut * you.experience_level / 4)); 
             int hurt = attacker->apply_ac(dmg);
 
             dprf(DIAG_COMBAT, "Spiny: dmg = %d hurt = %d", dmg, hurt);


### PR DESCRIPTION
This is similar to https://github.com/crawl/crawl/pull/249/files - however, due to Spiny in our forke being a rare mut that can potentially be attained by non-Demonspawn characters, we need it to be more closely tied to your mutation's level.

The other fix for this has damage that's almost entirely based on your XL. At higher level, that might be too good for someone who randomly got Spiny 1. At Spiny 3, these numbers will be almost the same as in alex's proposal. (unless I screwed up)

To do: demonspawn-fart-gas improvement, probably also borrow alex's PBD nerfs but again keeping non-Ds players in mind
