### PR TITLE
djinn can read books, just not scrolls

### DIFF
--- a/crawl-ref/source/item_use.cc
+++ b/crawl-ref/source/item_use.cc
@@ -2459,6 +2459,11 @@ string cannot_read_item_reason(const item_def &item)
     // Prevent hot lava orcs reading scrolls
     if (you.species == SP_LAVA_ORC && temperature_effect(LORC_NO_SCROLLS))
         return "You'd burn any scroll you tried to read!";
+        
+     if (you.species == SP_DJINNI)
+        return "You'd burn any scroll you tried to read!";
+    
+ 
 
     // don't waste the player's time reading known scrolls in situations where
     // they'd be useless


### PR DESCRIPTION
@jeremygurr this could probably "fall through" if I put a : at the end of the LORC NO SCROLLS line? then there'd only need to be one "you'd burn any scroll" message. Also what if djinn could read while transformed?! Might make sense if most or all of their racial stuff is suppressed while transformed - it would also give them a chance to use acq scrolls! What is a genie who can't make or grant wishes?!
